### PR TITLE
feat: adjust playbook styles

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "technical-playbook-manuel-technique",
+  "image": "mcr.microsoft.com/vscode/devcontainers/base:buster",
+
+  "features": {
+    "ruby": "2.7.6"
+  },
+
+  "containerEnv": {
+    "SHELL": "/bin/zsh"
+  },
+
+  "extensions": [
+    "github.copilot"
+  ],
+
+  "remoteUser": "vscode"
+}

--- a/assets/_sass/styles.scss
+++ b/assets/_sass/styles.scss
@@ -24,7 +24,7 @@ $slimmer: new-breakpoint(min-width 641px max-width 980px 12);
 
 @media screen {
   body {
-    background: $cds-yellow;
+    background: $white;
     font-family: $sans-serif;
     margin: 0;
     line-height: 1.5em;
@@ -96,7 +96,7 @@ $slimmer: new-breakpoint(min-width 641px max-width 980px 12);
 
   h4 {
     font-family: $sans-serif;
-    font-size: 17px;
+    font-size: 18px;
     font-weight: 700;
     line-height: 1.5em;
     color: $pacific_blue;
@@ -120,7 +120,7 @@ $slimmer: new-breakpoint(min-width 641px max-width 980px 12);
   p {
     color: $gray-dark;
     font-weight: 400;
-    font-size: 17px;
+    font-size: 18px;
     line-height: 2.0em;
   }
 
@@ -149,7 +149,7 @@ $slimmer: new-breakpoint(min-width 641px max-width 980px 12);
   }
 
   .button {
-    font-size: 17px;
+    font-size: 18px;
     font-family: $sans-serif;
     font-weight: 700;
     line-height: 1.5em;
@@ -266,6 +266,7 @@ $slimmer: new-breakpoint(min-width 641px max-width 980px 12);
     height: 0;
     background: $cds-black;
     color: $white;
+    border-bottom: 4px solid $cds-yellow;
     .outer_container {
       padding: 0 40px;
     }
@@ -495,7 +496,8 @@ $slimmer: new-breakpoint(min-width 641px max-width 980px 12);
 
     li {
       padding-left: 5px;
-      font-size: 17px;
+      font-size: 18px;
+      line-height: 28px;
     }
 
     ul {
@@ -503,7 +505,7 @@ $slimmer: new-breakpoint(min-width 641px max-width 980px 12);
     }
 
     a {
-      color: #000000;
+      color: $pacific_blue;
       text-decoration: underline;
       display: inline-block;
     }


### PR DESCRIPTION
# Summary
Update the playbook styles as follows:

- Slightly increase `#plays` font size (improve readability).
- Replace `#plays` yellow background with white (improve readability).
- Add bottom yellow border to floating nav (CDS branding).
- Update `#plays a` element colour to blue (convention).

Also added a .devcontainer for easier local setup.

# Updates
## Desktop
![image](https://user-images.githubusercontent.com/2110107/174204427-0f3adfb9-aec7-452c-85d5-7da7bb77683d.png)

## Mobile
![image](https://user-images.githubusercontent.com/2110107/174204524-6e30129c-5e70-4512-9f1f-809d5a18eab6.png)

# Related
* Closes #4 